### PR TITLE
Fix callback queries with unknown parameters

### DIFF
--- a/InlineCommand.cs
+++ b/InlineCommand.cs
@@ -31,6 +31,8 @@ namespace Telegram.Bot.Helper
             {
                 if (string.IsNullOrWhiteSpace(Commands[commandIndex]))
                     continue;
+                if (string.IsNullOrWhiteSpace(valueToCompareWith.Commands[commandIndex]))
+                    continue;
 
                 if (Commands[commandIndex] != valueToCompareWith.Commands[commandIndex])
                     return false;


### PR DESCRIPTION
This is a simple fix to use queries with unknown parameters, as described in the documentation.